### PR TITLE
Update react-tree-walker dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
     "webpack-hot-middleware": "2.18.0"
   },
   "dependencies": {
-    "react-tree-walker": "^2.1.0"
+    "react-tree-walker": "^2.1.1"
   }
 }


### PR DESCRIPTION
The current umd module uses the old 2.1.0 version