### PR TITLE
Fix typo on src/index on warn message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 import reactTreeWalker from 'react-tree-walker'
 
 const warnmsg =
-  '"react-async-bootstrapper" deprecation notice: please rename your "asyncBootsrap" methods to "bootstrap"'
+  '"react-async-bootstrapper" deprecation notice: please rename your "asyncBootstrap" methods to "bootstrap"'
 
 const defaultContext = {
   reactAsyncBootstrapperRunning: true,


### PR DESCRIPTION
- warn message `warnmsg` was refering to `asyncBootsrap` instead of `asyncBootstrap`